### PR TITLE
Updating the "Total Paid" value to not include certain order statuses

### DIFF
--- a/pmpro-member-history.php
+++ b/pmpro-member-history.php
@@ -27,7 +27,7 @@ function pmpro_member_history_profile_fields( $user ) {
 
 	$levelshistory = $wpdb->get_results("SELECT * FROM $wpdb->pmpro_memberships_users WHERE user_id = '$user->ID' ORDER BY id DESC");
 
-	$totalvalue = $wpdb->get_var("SELECT SUM(total) FROM $wpdb->pmpro_membership_orders WHERE user_id = '$user->ID' AND status NOT IN('refunded', 'review', 'token', 'error')");
+	$totalvalue = $wpdb->get_var("SELECT SUM(total) FROM $wpdb->pmpro_membership_orders WHERE user_id = '$user->ID' AND status NOT IN('token','review','pending','error','refunded')");
 
 	if ( $invoices || $levelshistory ) { ?>
 		<hr />

--- a/pmpro-member-history.php
+++ b/pmpro-member-history.php
@@ -27,7 +27,7 @@ function pmpro_member_history_profile_fields( $user ) {
 
 	$levelshistory = $wpdb->get_results("SELECT * FROM $wpdb->pmpro_memberships_users WHERE user_id = '$user->ID' ORDER BY id DESC");
 
-	$totalvalue = $wpdb->get_var("SELECT SUM(total) FROM $wpdb->pmpro_membership_orders WHERE user_id = '$user->ID'");
+	$totalvalue = $wpdb->get_var("SELECT SUM(total) FROM $wpdb->pmpro_membership_orders WHERE user_id = '$user->ID' AND status NOT IN('refunded', 'review', 'token', 'error')");
 
 	if ( $invoices || $levelshistory ) { ?>
 		<hr />


### PR DESCRIPTION
There was a bug in this Add On where the "Total Paid" was showing a sum of ALL orders, including review, token, error, pending, and refunded.

This updates the $totalvalue shown on the Member History section of the Edit User profile to exclude orders in these statuses.  